### PR TITLE
More robust error reporting

### DIFF
--- a/lib/googleadwords.js
+++ b/lib/googleadwords.js
@@ -148,6 +148,16 @@ var GoogleAdwords = function (spec, my) {
             if (results.body.indexOf('AuthenticationError.OAUTH_TOKEN_INVALID') > -1) {
               msg = 'Authentication Error. OAUTH_TOKEN_INVALID'
             }
+            
+            var errorPrefix = '<ApiError><type>'
+            var errorSuffix = '</type>'
+            var errorPrefixIndex = results.body.indexOf(errorPrefix)
+            if (errorPrefixIndex > -1) {
+              var errorIndex = errorPrefixIndex + errorPrefix.length
+              var errorIndexEnd = results.body.indexOf(errorSuffix)
+              msg = results.body.substring(errorIndex, errorIndexEnd)
+            }
+
             msg = msg || results.error
             return reject(msg)
           }


### PR DESCRIPTION
Allows _any_ error to be logged. This is a bit hacky, but it does the trick without an xml parser
